### PR TITLE
Add onFocus callback

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,6 +104,7 @@ export const Hint: React.FC<IHintProps> = props => {
             ...childProps,
             onChange,
             onBlur,
+            onFocus: onChange,
             onKeyDown,
             ref: mergeRefs(childProps.ref, mainInputRef)
         }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,6 +74,7 @@ export const Hint: React.FC<IHintProps> = props => {
 
     const onFocus = (e: React.ChangeEvent<HTMLInputElement>) => {
         setHint(getHint(e.target.value));
+        childProps.onFocus && childProps.onFocus(e);
     };
 
     const onBlur = (e: React.FocusEvent<HTMLInputElement>) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,6 +72,10 @@ export const Hint: React.FC<IHintProps> = props => {
         childProps.onChange && childProps.onChange(e);
     };
 
+    const onFocus = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setHint(getHint(e.target.value));
+    };
+
     const onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
         setHint('');
         childProps.onBlur && childProps.onBlur(e);
@@ -104,7 +108,7 @@ export const Hint: React.FC<IHintProps> = props => {
             ...childProps,
             onChange,
             onBlur,
-            onFocus: onChange,
+            onFocus,
             onKeyDown,
             ref: mergeRefs(childProps.ref, mainInputRef)
         }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,7 +72,7 @@ export const Hint: React.FC<IHintProps> = props => {
         childProps.onChange && childProps.onChange(e);
     };
 
-    const onFocus = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const onFocus = (e: React.FocusEvent<HTMLInputElement>) => {
         setHint(getHint(e.target.value));
         childProps.onFocus && childProps.onFocus(e);
     };


### PR DESCRIPTION
Currently when input is blurred, then focused again, the hint doesn't appear.
This PR aims to fix that.
When the focus is gained again, the hint is added to the input.